### PR TITLE
Improve `MemoryRegionStorage` search from O(n) to O(log n)

### DIFF
--- a/Source/AddressableMemory.cpp
+++ b/Source/AddressableMemory.cpp
@@ -53,10 +53,6 @@ bool BCRL::MemoryRegionStorage::Update()
 
 	fileStream.close();
 
-    std::sort(memoryRegions.begin(), memoryRegions.end(), [](const MemoryRegion& a, const MemoryRegion& b) {
-        return a.addressSpace.front() < b.addressSpace.front();
-    });
-
 	this->memoryRegions = memoryRegions;
 	return true;
 }


### PR DESCRIPTION
Also, `.find(char)` is faster than `.find(std::string)`, so I changed that as well.